### PR TITLE
Fix Clio gray overlay blocking links

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "node --test src/lib/toast-manager.test.ts",
     "preview": "vite preview",
     "deploy": "node updateVersionAndZip.cjs"
   },

--- a/src/lib/toast-manager.test.ts
+++ b/src/lib/toast-manager.test.ts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import { beforeEach, describe, it } from 'node:test';
+import { ToastManager } from './toast-manager.ts';
+
+class FakeElement {
+  public readonly attributes = new Map<string, string>();
+  public readonly style = { pointerEvents: '' };
+  public textContent = '';
+
+  public setAttribute(name: string, value: string): void {
+    this.attributes.set(name, value);
+  }
+}
+
+class FakeDocument {
+  public readonly children: FakeElement[] = [];
+  public readonly body = {
+    appendChild: (element: FakeElement) => {
+      this.children.push(element);
+      return element;
+    },
+  };
+
+  public createElement(): FakeElement {
+    return new FakeElement();
+  }
+
+  public findById(id: string): FakeElement | null {
+    return (
+      this.children.find((element) => element.attributes.get('id') === id) ??
+      null
+    );
+  }
+}
+
+let fakeDocument: FakeDocument;
+
+describe('ToastManager', () => {
+  beforeEach(() => {
+    fakeDocument = new FakeDocument();
+    Object.defineProperty(globalThis, 'document', {
+      configurable: true,
+      value: fakeDocument,
+    });
+  });
+
+  it('does not add an empty overlay when initialized', () => {
+    new ToastManager();
+
+    assert.equal(fakeDocument.findById('momane_toast'), null);
+  });
+
+  it('ignores blank toast messages', () => {
+    const manager = new ToastManager();
+
+    manager.showToast(' ');
+
+    assert.equal(fakeDocument.findById('momane_toast'), null);
+  });
+
+  it('makes a real toast non-interactive', () => {
+    const manager = new ToastManager();
+
+    manager.showToast('Document opened');
+
+    const toast = fakeDocument.findById('momane_toast');
+    assert.equal(toast?.textContent, 'Document opened');
+    assert.equal(toast?.style.pointerEvents, 'none');
+  });
+});

--- a/src/lib/toast-manager.ts
+++ b/src/lib/toast-manager.ts
@@ -1,13 +1,19 @@
 export class ToastManager {
-  private toast: HTMLDivElement;
-
-  constructor() {
-    this.toast = document.createElement('div');
-    this.toast.setAttribute('id', 'momane_toast');
-    document.body.appendChild(this.toast);
-  }
+  private toast: HTMLDivElement | null = null;
 
   public showToast(text: string): void {
-    console.log('Showing toast:', text);
+    const message = text.trim();
+
+    if (!message) return;
+
+    if (!this.toast) {
+      this.toast = document.createElement('div');
+      this.toast.setAttribute('id', 'momane_toast');
+      this.toast.setAttribute('role', 'status');
+      this.toast.style.pointerEvents = 'none';
+      document.body.appendChild(this.toast);
+    }
+
+    this.toast.textContent = message;
   }
 }


### PR DESCRIPTION
## What changed

- create the Faster Suite toast container only when a real message is shown
- ignore blank toast messages
- prevent the toast surface from intercepting pointer events
- add a regression suite for the empty-overlay behavior

## Why

A recent Clio layout change exposed an extension-side bug: the extension eagerly inserted an empty fixed-position gray toast element. That element could overlap Clio links and intercept clicks even though no toast was visible.

## Verification

- `npm test` — 3/3 passing
- `npm run build` — passing production build
- targeted ESLint on the changed source and regression test — passing
