### PR TITLE
Restore extension quality gates

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,7 +5,9 @@ import reactRefresh from 'eslint-plugin-react-refresh'
 import tseslint from 'typescript-eslint'
 
 export default tseslint.config(
-  { ignores: ['dist'] },
+  {
+    ignores: ['dist', 'public/assets/js/**', 'src/assets/js/**'],
+  },
   {
     extends: [js.configs.recommended, ...tseslint.configs.recommended],
     files: ['**/*.{ts,tsx}'],

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
+    "check": "npm run lint && npm run build",
     "lint": "eslint .",
     "test": "node --test src/lib/toast-manager.test.ts",
     "preview": "vite preview",

--- a/src/components/Setting.tsx
+++ b/src/components/Setting.tsx
@@ -1,19 +1,18 @@
-import React from 'react';
-import { Control } from 'react-hook-form';
+import { Control, FieldValues, Path } from 'react-hook-form';
 import { FormControl, FormDescription, FormField, FormItem } from './ui/form';
 import { Switch } from './ui/switch';
 
-type Props<TFormValues extends Record<string, any>> = {
+type Props<TFormValues extends FieldValues> = {
   description: string;
-  controlName: keyof TFormValues & string;
-  control: Control<TFormValues, any>;
+  controlName: Path<TFormValues>;
+  control: Control<TFormValues>;
 };
 
-const SettingsContainer: React.FC<Props<any>> = ({
+const SettingsContainer = <TFormValues extends FieldValues>({
   description,
   controlName,
   control,
-}) => {
+}: Props<TFormValues>) => {
   return (
     <FormField
       control={control}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -53,4 +53,4 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 )
 Button.displayName = "Button"
 
-export { Button, buttonVariants }
+export { Button }

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -166,7 +166,6 @@ const FormMessage = React.forwardRef<
 FormMessage.displayName = 'FormMessage';
 
 export {
-  useFormField,
   Form,
   FormItem,
   FormLabel,

--- a/src/popup/Popup.tsx
+++ b/src/popup/Popup.tsx
@@ -20,21 +20,15 @@ const Popup: React.FC = () => {
       pacer_notify_when_archived: true,
     },
   });
-  const [initialValues, setInitialValues] = useState<SettingsSchemaType>({
-    clio_open_docs: true,
-    clio_enhance_docs: true,
-    pacer_auto_save_and_archive: true,
-    pacer_notify_when_archived: true,
-  });
   const [loading, setLoading] = useState(true);
+  const { reset } = form;
 
   useEffect(() => {
     const loadSettings = async () => {
       try {
         const settings = await getSettings();
 
-        form.reset(settings);
-        setInitialValues(settings || initialValues);
+        reset(settings);
       } catch (error) {
         console.error('Error loading settings:', error);
       } finally {
@@ -42,7 +36,7 @@ const Popup: React.FC = () => {
       }
     };
     loadSettings();
-  }, []);
+  }, [reset]);
 
   useEffect(() => {
     const subscription = form.watch(async (data) => {


### PR DESCRIPTION
## What changed

- exclude copied vendor JavaScript from application linting
- replace unsafe React Hook Form `any` types with `FieldValues` and `Path<T>` generics
- remove unused Fast Refresh exports
- correct the popup settings-load effect dependencies and remove dead state
- add `npm run check` as the deterministic lint-and-build gate

## Why

The repository's lint command failed with five errors and eleven warnings, mixing copied jQuery diagnostics with genuine application typing and hook issues. This restores a clean gate without modifying vendor code or changing popup behavior.

## Verification

- clean `npm ci`
- `npm test` — Clio overlay regression 3/3 passing
- `npm run check` — zero lint findings and passing production build
- `npm audit --omit=dev` — zero vulnerabilities
- Manifest V3 artifact scan — all 20 referenced files present
- unpacked Chromium load — extension service worker registered successfully
