### PR TITLE
Bound Clio listener and link lifecycles

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,9 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "check": "npm run lint && npm run build",
+    "check": "npm test && npm run lint && npm run build",
     "lint": "eslint .",
-    "test": "node --test src/lib/toast-manager.test.ts",
+    "test": "node --test src/lib/toast-manager.test.ts test/document-actions-listeners.test.ts",
     "preview": "vite preview",
     "deploy": "node updateVersionAndZip.cjs"
   },

--- a/src/lib/document-actions-listeners.ts
+++ b/src/lib/document-actions-listeners.ts
@@ -1,0 +1,27 @@
+const boundDocuments = new WeakSet<Document>();
+
+export function bindDocumentActionsDismissal(
+  targetDocument: Document,
+  targetWindow: Window
+): void {
+  if (boundDocuments.has(targetDocument)) return;
+  boundDocuments.add(targetDocument);
+
+  targetDocument.addEventListener('click', (event) => {
+    if (
+      !(event.target as HTMLElement).closest(
+        '.fasterlaw-actions-container, .fasterlaw-icon'
+      )
+    ) {
+      targetDocument
+        .querySelectorAll('.fasterlaw-actions-container')
+        .forEach((container) => container.classList.remove('open'));
+    }
+  });
+
+  targetWindow.addEventListener('wheel', () => {
+    targetDocument
+      .querySelectorAll('.fasterlaw-actions-container')
+      .forEach((container) => container.classList.remove('open'));
+  });
+}

--- a/src/lib/document-link-manager.ts
+++ b/src/lib/document-link-manager.ts
@@ -1,6 +1,7 @@
 import { Action, DocumentLink, LinkType } from '@/types/clio';
 import { bindDocumentActionsDismissal } from './document-actions-listeners';
 import { EnhancedDocumentLink } from './enhanced-document-link';
+import { pruneDisconnectedDocumentLinks } from './managed-document-links';
 
 /**
  *  DocumentLinkManager is responsible for managing document links on the page.
@@ -10,7 +11,6 @@ import { EnhancedDocumentLink } from './enhanced-document-link';
  *  already enhanced nodes.
  */
 export class DocumentLinkManager {
-  private enhancedNodes: HTMLElement[] = [];
   private enhancedLinks: EnhancedDocumentLink[] = [];
 
   /**
@@ -24,12 +24,12 @@ export class DocumentLinkManager {
    *  This method should be called when the page is ready to ensure all links are processed.
    */
   public enhanceDocumentLinks(): void {
+    this.pruneDetachedLinks();
     const documentLinks = this.getDocumentLinks();
 
     documentLinks.forEach((documentLink) => {
       const enhancedLink = new EnhancedDocumentLink(documentLink);
       this.addActionsToEnhancedLink(enhancedLink);
-      this.enhancedNodes.push(documentLink.node);
       this.enhancedLinks.push(enhancedLink);
     });
 
@@ -39,12 +39,14 @@ export class DocumentLinkManager {
   }
 
   public enableEnhancedLinks(): void {
+    this.pruneDetachedLinks();
     this.enhancedLinks.forEach((link) => {
       link.setEnhance(true);
     });
   }
 
   public disableEnhancedLinks(): void {
+    this.pruneDetachedLinks();
     this.enhancedLinks.forEach((link) => {
       link.setEnhance(false);
     });
@@ -57,7 +59,9 @@ export class DocumentLinkManager {
    *  It also binds click events to these actions to perform the corresponding operations.
    */
   private getDocumentLinks(): DocumentLink[] {
-    const enhancedNodesSet = new Set(this.enhancedNodes);
+    const enhancedNodesSet = new Set(
+      this.enhancedLinks.map((enhancedLink) => enhancedLink.node)
+    );
 
     // Collect all document links from the page, filtering out already enhanced nodes
     const documentDocLinks = Array.from(
@@ -106,13 +110,38 @@ export class DocumentLinkManager {
       ...detailsDocLinks,
     ];
     const seen = new Set<HTMLElement>();
+    const seenActionHosts = new Set(
+      this.enhancedLinks
+        .map((enhancedLink) =>
+          this.getDocumentActionHost(enhancedLink.node)
+        )
+        .filter((host): host is HTMLElement => host !== null)
+    );
     const unique = combined.filter((dl) => {
       if (seen.has(dl.node)) return false;
+
+      const actionHost = this.getDocumentActionHost(dl.node);
+      if (actionHost && seenActionHosts.has(actionHost)) return false;
+
       seen.add(dl.node);
+      if (actionHost) seenActionHosts.add(actionHost);
       return true;
     });
 
     return unique;
+  }
+
+  private pruneDetachedLinks(): void {
+    this.enhancedLinks = pruneDisconnectedDocumentLinks(this.enhancedLinks);
+  }
+
+  private getDocumentActionHost(node: HTMLElement): HTMLElement | null {
+    const row = node.parentElement?.closest('tr');
+    return (
+      (row?.querySelector('cc-document-actions')?.parentElement as
+        | HTMLElement
+        | null) ?? null
+    );
   }
 
   /**

--- a/src/lib/document-link-manager.ts
+++ b/src/lib/document-link-manager.ts
@@ -1,4 +1,5 @@
 import { Action, DocumentLink, LinkType } from '@/types/clio';
+import { bindDocumentActionsDismissal } from './document-actions-listeners';
 import { EnhancedDocumentLink } from './enhanced-document-link';
 
 /**
@@ -34,7 +35,7 @@ export class DocumentLinkManager {
 
     console.log(documentLinks);
 
-    this.clickOutsideEventBinding();
+    bindDocumentActionsDismissal(document, window);
   }
 
   public enableEnhancedLinks(): void {
@@ -212,32 +213,6 @@ export class DocumentLinkManager {
     }
 
     return docId;
-  }
-
-  /**
-   *  Binds a click event to the document to close the actions container
-   *  when clicking outside of it. This ensures that the actions container
-   *  is closed when the user clicks anywhere outside of the actions container
-   *  or the icon that opens it.
-   */
-  private clickOutsideEventBinding(): void {
-    document.addEventListener('click', (event) => {
-      if (
-        !(event.target as HTMLElement).closest(
-          '.fasterlaw-actions-container, .fasterlaw-icon'
-        )
-      ) {
-        document
-          .querySelectorAll('.fasterlaw-actions-container')
-          .forEach((container) => container?.classList.remove('open'));
-      }
-    });
-
-    window.addEventListener('wheel', () => {
-      document
-        .querySelectorAll('.fasterlaw-actions-container')
-        .forEach((container) => container?.classList.remove('open'));
-    });
   }
 
   /**

--- a/src/lib/enhanced-document-link.ts
+++ b/src/lib/enhanced-document-link.ts
@@ -10,6 +10,63 @@ export class EnhancedDocumentLink {
   private actionsContainer: HTMLDivElement;
   private enhanced = false;
   private downloadsEnabled = false;
+  private detailsObserver?: MutationObserver;
+  private detailsLinkContainer?: HTMLDivElement;
+  private detailsLinkHost?: HTMLElement;
+  private iconHost?: HTMLElement;
+  private iconHostLastButton?: HTMLElement;
+  private iconHostLastButtonTopRadius = '';
+  private iconHostLastButtonBottomRadius = '';
+  private ownsFasterLawIcon = false;
+  private launcherIcon?: HTMLElement;
+  private destroyed = false;
+
+  private readonly fasterLawIconClickHandler = () => {
+    this.toggleActionsContainer();
+    this.positionActionsContainer();
+  };
+
+  private readonly nodeMouseDownHandler = () => {
+    this.node.removeEventListener(
+      'click',
+      EnhancedDocumentLink.cancelClick,
+      true
+    );
+
+    this.node.addEventListener(
+      'click',
+      EnhancedDocumentLink.cancelClick,
+      true
+    );
+
+    EnhancedDocumentLink.handleDocumentHandler(
+      this.linkType,
+      this.docID,
+      this.node
+    );
+  };
+
+  private readonly launcherMouseDownHandler = () => {
+    if (!this.launcherIcon) return;
+
+    this.launcherIcon.removeEventListener(
+      'click',
+      EnhancedDocumentLink.cancelClick,
+      true
+    );
+
+    this.launcherIcon.addEventListener(
+      'click',
+      EnhancedDocumentLink.cancelClick,
+      true
+    );
+
+    EnhancedDocumentLink.handleDocumentHandler(
+      this.linkType,
+      this.docID,
+      this.launcherIcon
+    );
+  };
 
   public get node(): HTMLElement {
     return this._node;
@@ -100,6 +157,23 @@ export class EnhancedDocumentLink {
       ?.parentNode as HTMLElement;
 
     if (targetViewElement) {
+      const enhance = await getSetting('clio_enhance_docs');
+      if (this.destroyed || !targetViewElement.isConnected) return;
+
+      // Prevent duplicate icon injection if one already exists in the host cell.
+      const existingIcon = targetViewElement.querySelector(
+        '.fasterlaw-icon.new-ui'
+      ) as HTMLDivElement | null;
+      if (existingIcon) {
+        this.fasterLawIcon.removeEventListener(
+          'click',
+          this.fasterLawIconClickHandler
+        );
+        this.fasterLawIcon = existingIcon;
+        return;
+      }
+
+      this.iconHost = targetViewElement;
       targetViewElement.classList.add('fasterlaw-icon-host');
 
       // Style existing elements
@@ -108,23 +182,18 @@ export class EnhancedDocumentLink {
       ) as HTMLElement;
 
       if (lastBtn) {
+        this.iconHostLastButton = lastBtn;
+        this.iconHostLastButtonTopRadius =
+          lastBtn.style.borderTopRightRadius;
+        this.iconHostLastButtonBottomRadius =
+          lastBtn.style.borderBottomRightRadius;
         lastBtn.style.borderTopRightRadius = '0';
         lastBtn.style.borderBottomRightRadius = '0';
       }
 
-      const enhance = await getSetting('clio_enhance_docs');
       this.setEnhance(enhance ?? false);
-
-      // Prevent duplicate icon injection if one already exists in the host cell
-      const existingIcon = targetViewElement.querySelector(
-        '.fasterlaw-icon.new-ui'
-      ) as HTMLDivElement | null;
-      if (!existingIcon) {
-        targetViewElement.append(this.fasterLawIcon);
-      } else {
-        // Reuse the existing icon to avoid duplicates
-        this.fasterLawIcon = existingIcon;
-      }
+      targetViewElement.append(this.fasterLawIcon);
+      this.ownsFasterLawIcon = true;
     }
   }
 
@@ -161,6 +230,7 @@ export class EnhancedDocumentLink {
     const parentNode = this._node.parentNode as HTMLElement;
 
     parentNode.classList.add('fasterlaw-details-open-link-host');
+    this.detailsLinkHost = parentNode;
 
     icon.setAttribute('aria-hidden', 'true');
     icon.setAttribute('role', 'img');
@@ -183,6 +253,7 @@ export class EnhancedDocumentLink {
     linkContainer.appendChild(icon);
 
     this._node.parentNode?.appendChild(linkContainer);
+    this.detailsLinkContainer = linkContainer;
 
     const wrappedCallback = (
       mutationsList: MutationRecord[],
@@ -193,9 +264,52 @@ export class EnhancedDocumentLink {
 
     // Create an observer instance linked to the wrapped callback function
     const observer = new MutationObserver(wrappedCallback);
+    this.detailsObserver = observer;
 
     // Start observing the target element with the configured parameters
     observer.observe(this.node, config);
+  }
+
+  public destroy(): void {
+    if (this.destroyed) return;
+    this.destroyed = true;
+
+    this.detailsObserver?.disconnect();
+    this.fasterLawIcon.removeEventListener(
+      'click',
+      this.fasterLawIconClickHandler
+    );
+    this.node.removeEventListener('mousedown', this.nodeMouseDownHandler);
+    this.node.removeEventListener(
+      'click',
+      EnhancedDocumentLink.cancelClick,
+      true
+    );
+    this.launcherIcon?.removeEventListener(
+      'mousedown',
+      this.launcherMouseDownHandler
+    );
+    this.launcherIcon?.removeEventListener(
+      'click',
+      EnhancedDocumentLink.cancelClick,
+      true
+    );
+    this.detailsLinkContainer?.remove();
+    this.actionsContainer.remove();
+    this.detailsLinkHost?.classList.remove(
+      'fasterlaw-details-open-link-host'
+    );
+
+    if (this.ownsFasterLawIcon) {
+      this.fasterLawIcon.remove();
+      this.iconHost?.classList.remove('fasterlaw-icon-host');
+      if (this.iconHostLastButton) {
+        this.iconHostLastButton.style.borderTopRightRadius =
+          this.iconHostLastButtonTopRadius;
+        this.iconHostLastButton.style.borderBottomRightRadius =
+          this.iconHostLastButtonBottomRadius;
+      }
+    }
   }
 
   public bypassClick(): void {
@@ -211,62 +325,23 @@ export class EnhancedDocumentLink {
 
   private attachEventListeners(): void {
     // Actions panel
-    this.fasterLawIcon.addEventListener('click', () => {
-      this.toggleActionsContainer();
-      this.positionActionsContainer();
-    });
+    this.fasterLawIcon.addEventListener(
+      'click',
+      this.fasterLawIconClickHandler
+    );
 
     // Link
-    this.node.addEventListener('mousedown', () => {
-      this.node.removeEventListener(
-        'click',
-        EnhancedDocumentLink.cancelClick,
-        true
-      );
-
-      this.node.addEventListener(
-        'click',
-        EnhancedDocumentLink.cancelClick,
-        true
-      );
-
-      EnhancedDocumentLink.handleDocumentHandler(
-        this.linkType,
-        this.docID,
-        this.node
-      );
-
-      return false;
-    });
+    this.node.addEventListener('mousedown', this.nodeMouseDownHandler);
 
     // Open launcher icon
-    const launcherIcon = this.node
+    this.launcherIcon = this.node
       .closest('td')
       ?.querySelector('a[ng-click*="handleLauncherClick"]') as HTMLElement;
 
-    launcherIcon?.addEventListener('mousedown', () => {
-      // console.log('In launcher icon click handler. Clicked:', this.node);
-
-      launcherIcon?.removeEventListener(
-        'click',
-        EnhancedDocumentLink.cancelClick,
-        true
-      );
-
-      launcherIcon.addEventListener(
-        'click',
-        EnhancedDocumentLink.cancelClick,
-        true
-      );
-
-      EnhancedDocumentLink.handleDocumentHandler(
-        this.linkType,
-        this.docID,
-        launcherIcon
-      );
-
-      return false;
-    });
+    this.launcherIcon?.addEventListener(
+      'mousedown',
+      this.launcherMouseDownHandler
+    );
   }
 
   public static cancelClick(e: MouseEvent) {

--- a/src/lib/managed-document-links.ts
+++ b/src/lib/managed-document-links.ts
@@ -1,0 +1,15 @@
+export interface ManagedDocumentLink {
+  readonly node: Node;
+  destroy(): void;
+}
+
+export function pruneDisconnectedDocumentLinks<T extends ManagedDocumentLink>(
+  links: T[]
+): T[] {
+  return links.filter((link) => {
+    if (link.node.isConnected) return true;
+
+    link.destroy();
+    return false;
+  });
+}

--- a/test/document-actions-listeners.test.ts
+++ b/test/document-actions-listeners.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { bindDocumentActionsDismissal } from '../src/lib/document-actions-listeners.ts';
+import { pruneDisconnectedDocumentLinks } from '../src/lib/managed-document-links.ts';
 
 test('binds document-action dismissal listeners only once per document', () => {
   const registrations = { click: 0, wheel: 0 };
@@ -51,4 +52,29 @@ test('binds listeners for a newly loaded document', () => {
   bindDocumentActionsDismissal(secondDocument, targetWindow);
 
   assert.equal(clickRegistrations, 2);
+});
+
+test('destroys and releases document links after Clio detaches them', () => {
+  const destroyed: string[] = [];
+  const links = [
+    {
+      id: 'connected',
+      node: { isConnected: true } as Node,
+      destroy() {
+        destroyed.push(this.id);
+      },
+    },
+    {
+      id: 'detached',
+      node: { isConnected: false } as Node,
+      destroy() {
+        destroyed.push(this.id);
+      },
+    },
+  ];
+
+  const retained = pruneDisconnectedDocumentLinks(links);
+
+  assert.deepEqual(retained.map((link) => link.id), ['connected']);
+  assert.deepEqual(destroyed, ['detached']);
 });

--- a/test/document-actions-listeners.test.ts
+++ b/test/document-actions-listeners.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { bindDocumentActionsDismissal } from '../src/lib/document-actions-listeners.ts';
+
+test('binds document-action dismissal listeners only once per document', () => {
+  const registrations = { click: 0, wheel: 0 };
+  const targetDocument = {
+    addEventListener(type: string) {
+      if (type === 'click') registrations.click += 1;
+    },
+    querySelectorAll() {
+      return [];
+    },
+  } as unknown as Document;
+  const targetWindow = {
+    addEventListener(type: string) {
+      if (type === 'wheel') registrations.wheel += 1;
+    },
+  } as unknown as Window;
+
+  bindDocumentActionsDismissal(targetDocument, targetWindow);
+  bindDocumentActionsDismissal(targetDocument, targetWindow);
+  bindDocumentActionsDismissal(targetDocument, targetWindow);
+
+  assert.deepEqual(registrations, { click: 1, wheel: 1 });
+});
+
+test('binds listeners for a newly loaded document', () => {
+  let clickRegistrations = 0;
+  const firstDocument = {
+    addEventListener(type: string) {
+      if (type === 'click') clickRegistrations += 1;
+    },
+    querySelectorAll() {
+      return [];
+    },
+  } as unknown as Document;
+  const secondDocument = {
+    addEventListener(type: string) {
+      if (type === 'click') clickRegistrations += 1;
+    },
+    querySelectorAll() {
+      return [];
+    },
+  } as unknown as Document;
+  const targetWindow = {
+    addEventListener() {},
+  } as unknown as Window;
+
+  bindDocumentActionsDismissal(firstDocument, targetWindow);
+  bindDocumentActionsDismissal(secondDocument, targetWindow);
+
+  assert.equal(clickRegistrations, 2);
+});


### PR DESCRIPTION
## What changed

- bind document-click and window-wheel action-dismissal listeners only once per document
- prune enhanced document links after Clio detaches their DOM nodes
- disconnect details-page mutation observers and unregister per-link handlers during disposal
- remove detached action menus and restore extension-modified host styling
- enforce one managed enhanced link per Clio action host
- run both the toast-overlay and listener lifecycle regressions from `npm test`
- make `npm run check` execute tests, lint, and the production build

## Why

Clio's mutation observer repeatedly calls document-link enhancement. The prior implementation registered fresh global listeners on every call and retained detached links, menus, and observers indefinitely, so long-lived Clio sessions accumulated callbacks and DOM resources.

## Verification

- clean `npm ci`
- `npm run check` — 6/6 tests, zero lint findings, passing production build
- `npm audit --omit=dev` — zero vulnerabilities
- Manifest V3 artifact scan — all 20 referenced files present
- unpacked Chromium load — extension service worker registered successfully
- independent lifecycle review — no remaining findings after ownership and async-cleanup corrections
