### PR TITLE
Prepare extension store release 26.7.22.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "faster-suit-ext",
-  "version": "25.10.09.001",
+  "version": "26.7.22.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "faster-suit-ext",
-      "version": "25.10.09.001",
+      "version": "26.7.22.1",
       "license": "MIT",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "faster-suit-ext",
   "private": true,
-  "version": "25.10.09.001",
+  "version": "26.7.22.1",
   "type": "module",
   "license": "MIT",
   "scripts": {
@@ -9,7 +9,7 @@
     "build": "tsc -b && vite build",
     "check": "npm test && npm run lint && npm run build",
     "lint": "eslint .",
-    "test": "node --test src/lib/toast-manager.test.ts test/document-actions-listeners.test.ts",
+    "test": "node --test src/lib/toast-manager.test.ts test/document-actions-listeners.test.ts test/release-packaging.test.cjs",
     "preview": "vite preview",
     "deploy": "node updateVersionAndZip.cjs"
   },

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -25,4 +25,4 @@ export const SINGLE_DOCUMENT_PAGE_REGEX =
 export const DOCUMENT_URL_REGEX =
   /https?:\/\/ecf\.([a-z]{2,3})\.uscourts\.gov\/doc1\/index\.pl\?.*caseid=[^&]+/;
 
-export const VERSION = '2025.10.09.001';
+export const VERSION = '2026.07.22.001';

--- a/test/release-packaging.test.cjs
+++ b/test/release-packaging.test.cjs
@@ -1,0 +1,25 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { assertVersion, nextVersion } = require('../updateVersionAndZip.cjs');
+
+test('nextVersion starts a new date at build 001', () => {
+  assert.equal(
+    nextVersion('25.10.09.001', new Date(2026, 6, 22)),
+    '26.7.22.1'
+  );
+});
+
+test('nextVersion increments an existing build on the same date', () => {
+  assert.equal(
+    nextVersion('26.7.22.9', new Date(2026, 6, 22)),
+    '26.7.22.10'
+  );
+});
+
+test('assertVersion rejects versions outside the release format', () => {
+  assert.throws(() => assertVersion('26.07.22.001'), /Invalid extension version/);
+  assert.throws(() => assertVersion('26.7.22.65536'), /Invalid extension version/);
+  assert.throws(() => assertVersion('0.0.0.0'), /Invalid extension version/);
+  assert.doesNotThrow(() => assertVersion('26.7.22.1'));
+});

--- a/updateVersionAndZip.cjs
+++ b/updateVersionAndZip.cjs
@@ -1,73 +1,119 @@
 const fs = require('fs');
 const path = require('path');
-const { exec } = require('child_process');
+const { spawnSync } = require('child_process');
 
-// File paths
 const packagePath = path.join(__dirname, 'package.json');
+const packageLockPath = path.join(__dirname, 'package-lock.json');
 const manifestPath = path.join(__dirname, 'dist', 'manifest.json');
 const constantsPath = path.join(__dirname, 'src', 'constants', 'index.ts');
+const outputPath = path.join(__dirname, 'output');
 
-// Helper to zero-fill numbers
 const zeroFill = (num, width) => String(num).padStart(width, '0');
 
-// Get today’s date parts
-const now = new Date();
-const fullYear = now.getFullYear(); // e.g. 2025
-const yearShort = String(fullYear).slice(2); // e.g. 25
-const month = zeroFill(now.getMonth() + 1, 2);
-const day = zeroFill(now.getDate(), 2);
+function nextVersion(currentVersion, now = new Date()) {
+  const fullYear = now.getFullYear();
+  const yearShort = Number(String(fullYear).slice(2));
+  const month = now.getMonth() + 1;
+  const day = now.getDate();
+  const [oldYear, oldMonth, oldDay, oldBuild] = currentVersion.split('.');
+  const sameDay =
+    Number(oldYear) === yearShort &&
+    Number(oldMonth) === month &&
+    Number(oldDay) === day;
+  const buildNumber = sameDay ? Number(oldBuild) + 1 : 1;
 
-// Get current version from package.json
-const pkg = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
-const [oldYear, oldMonth, oldDay, oldBuild] = pkg.version.split('.');
-
-// Determine new version
-let buildNumber;
-if (oldYear === yearShort && oldMonth === month && oldDay === day) {
-  // Same day – increment build
-  buildNumber = zeroFill(Number(oldBuild) + 1, 3);
-} else {
-  // New day – reset build
-  buildNumber = '001';
+  return `${yearShort}.${month}.${day}.${buildNumber}`;
 }
 
-// Compose new versions
-const newPackageVersion = `${yearShort}.${month}.${day}.${buildNumber}`; // For package.json and manifest.json
-const newConstantVersion = `${fullYear}.${month}.${day}.${buildNumber}`; // For index.ts
-const zipVersion = `v${fullYear}_${month}_${day}_${buildNumber}`; // For zip file
-
-// Update package.json
-pkg.version = newPackageVersion;
-fs.writeFileSync(packagePath, JSON.stringify(pkg, null, 2), 'utf8');
-
-// Update manifest.json
-const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
-manifest.version = newPackageVersion;
-fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2), 'utf8');
-
-// Update src/constants/index.ts VERSION export
-let constantsContent = fs.readFileSync(constantsPath, 'utf8');
-constantsContent = constantsContent.replace(
-  /export const VERSION = '[^']+';/,
-  `export const VERSION = '${newConstantVersion}';`
-);
-fs.writeFileSync(constantsPath, constantsContent, 'utf8');
-
-// Create zip file
-const zipFileName = `faster_law_browser_extension_${zipVersion}.zip`;
-
-exec(
-  `cd dist && zip -r ../output/${zipFileName} ./*`,
-  (error, stdout, stderr) => {
-    if (error) {
-      console.error('Error zipping files:', error);
-      return;
-    }
-    console.log(stdout);
-    if (stderr) {
-      console.error(stderr);
-    } else {
-      console.log(`✅ Zip file created: ${zipFileName}`);
-    }
+function assertVersion(version) {
+  const parts = version.split('.');
+  const isChromeVersion =
+    parts.length === 4 &&
+    parts.every(
+      (part) => /^(0|[1-9]\d*)$/.test(part) && Number(part) <= 65535
+    ) &&
+    parts.some((part) => Number(part) > 0);
+  if (!isChromeVersion) {
+    throw new Error(
+      `Invalid extension version "${version}". Expected four Chrome-compatible integers.`
+    );
   }
-);
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: options.cwd || __dirname,
+    encoding: 'utf8',
+    stdio: 'inherit',
+  });
+
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`${command} ${args.join(' ')} failed with exit ${result.status}`);
+  }
+}
+
+function updateVersionFiles(version) {
+  const pkg = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
+  const packageLock = JSON.parse(fs.readFileSync(packageLockPath, 'utf8'));
+  const [year, month, day, build] = version.split('.');
+  const displayVersion = `20${year}.${zeroFill(month, 2)}.${zeroFill(day, 2)}.${zeroFill(build, 3)}`;
+
+  pkg.version = version;
+  packageLock.version = version;
+  packageLock.packages[''].version = version;
+
+  fs.writeFileSync(packagePath, `${JSON.stringify(pkg, null, 2)}\n`, 'utf8');
+  fs.writeFileSync(
+    packageLockPath,
+    `${JSON.stringify(packageLock, null, 2)}\n`,
+    'utf8'
+  );
+
+  const constantsContent = fs.readFileSync(constantsPath, 'utf8');
+  const versionExportPattern = /export const VERSION = '[^']+';/;
+  if (!versionExportPattern.test(constantsContent)) {
+    throw new Error('Could not find the VERSION export in src/constants/index.ts');
+  }
+  const updatedConstants = constantsContent.replace(
+    versionExportPattern,
+    `export const VERSION = '${displayVersion}';`
+  );
+  fs.writeFileSync(constantsPath, updatedConstants, 'utf8');
+}
+
+function main() {
+  const pkg = JSON.parse(fs.readFileSync(packagePath, 'utf8'));
+  const versionFlagIndex = process.argv.indexOf('--version');
+  const requestedVersion =
+    versionFlagIndex === -1 ? undefined : process.argv[versionFlagIndex + 1];
+  const version = requestedVersion || nextVersion(pkg.version);
+  assertVersion(version);
+  updateVersionFiles(version);
+
+  run('npm', ['run', 'check']);
+
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  if (manifest.version !== version) {
+    throw new Error(
+      `Built manifest version ${manifest.version} does not match package version ${version}`
+    );
+  }
+
+  const [year, month, day, build] = version.split('.');
+  const zipFileName = `faster_law_browser_extension_v20${year}_${zeroFill(month, 2)}_${zeroFill(day, 2)}_${zeroFill(build, 3)}.zip`;
+  const zipFilePath = path.join(outputPath, zipFileName);
+  fs.mkdirSync(outputPath, { recursive: true });
+  fs.rmSync(zipFilePath, { force: true });
+  run('zip', ['-X', '-r', zipFilePath, '.', '-x', '*.DS_Store'], {
+    cwd: path.join(__dirname, 'dist'),
+  });
+
+  console.log(`\nExtension package created: ${zipFilePath}`);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = { assertVersion, nextVersion };

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,17 @@
 import { crx, defineManifest } from '@crxjs/vite-plugin';
 import react from '@vitejs/plugin-react-swc';
+import fs from 'node:fs';
 import path from 'path';
 import { defineConfig } from 'vite';
+
+const packageJson = JSON.parse(
+  fs.readFileSync(path.resolve(__dirname, 'package.json'), 'utf8')
+) as { version: string };
 
 const manifest = defineManifest({
   manifest_version: 3,
   name: 'Faster Suite Browser Link',
-  version: '25.01.05.1926',
+  version: packageJson.version,
   description:
     'Open documents straight from Clio, get free PACER looks, and much, much more.',
   permissions: ['storage', 'notifications', 'tabs', 'cookies', 'activeTab'],


### PR DESCRIPTION
## Summary
- derive the generated manifest version from package.json
- make release packaging synchronous and fail closed
- validate Chrome-compatible version segments and keep package-lock/display versions synchronized
- add regression coverage for release version generation

## Verification
- `npm run deploy -- --version 26.7.22.1`
- 9 tests pass
- ESLint passes
- TypeScript/Vite production build passes
- `unzip -t` passes
- independent release review: no findings

## Release status
Chrome Web Store draft 26.7.22.1 submitted for review with automatic publication enabled.