### PR TITLE
Fix Clio custom field navigation

### DIFF
--- a/src/lib/document-link-manager.ts
+++ b/src/lib/document-link-manager.ts
@@ -1,7 +1,10 @@
 import { Action, DocumentLink, LinkType } from '@/types/clio';
 import { bindDocumentActionsDismissal } from './document-actions-listeners';
 import { EnhancedDocumentLink } from './enhanced-document-link';
-import { pruneDisconnectedDocumentLinks } from './managed-document-links';
+import {
+  hasValidDocumentId,
+  pruneDisconnectedDocumentLinks,
+} from './managed-document-links';
 
 /**
  *  DocumentLinkManager is responsible for managing document links on the page.
@@ -32,8 +35,6 @@ export class DocumentLinkManager {
       this.addActionsToEnhancedLink(enhancedLink);
       this.enhancedLinks.push(enhancedLink);
     });
-
-    console.log(documentLinks);
 
     bindDocumentActionsDismissal(document, window);
   }
@@ -118,6 +119,7 @@ export class DocumentLinkManager {
         .filter((host): host is HTMLElement => host !== null)
     );
     const unique = combined.filter((dl) => {
+      if (!hasValidDocumentId(dl)) return false;
       if (seen.has(dl.node)) return false;
 
       const actionHost = this.getDocumentActionHost(dl.node);

--- a/src/lib/managed-document-links.ts
+++ b/src/lib/managed-document-links.ts
@@ -3,6 +3,10 @@ export interface ManagedDocumentLink {
   destroy(): void;
 }
 
+export function hasValidDocumentId(link: { readonly docID: string }): boolean {
+  return /^\d+$/.test(link.docID);
+}
+
 export function pruneDisconnectedDocumentLinks<T extends ManagedDocumentLink>(
   links: T[]
 ): T[] {

--- a/test/document-actions-listeners.test.ts
+++ b/test/document-actions-listeners.test.ts
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import { bindDocumentActionsDismissal } from '../src/lib/document-actions-listeners.ts';
-import { pruneDisconnectedDocumentLinks } from '../src/lib/managed-document-links.ts';
+import {
+  hasValidDocumentId,
+  pruneDisconnectedDocumentLinks,
+} from '../src/lib/managed-document-links.ts';
 
 test('binds document-action dismissal listeners only once per document', () => {
   const registrations = { click: 0, wheel: 0 };
@@ -77,4 +80,10 @@ test('destroys and releases document links after Clio detaches them', () => {
 
   assert.deepEqual(retained.map((link) => link.id), ['connected']);
   assert.deepEqual(destroyed, ['detached']);
+});
+
+test('rejects Clio navigation links without a document ID', () => {
+  assert.equal(hasValidDocumentId({ docID: '1802754888' }), true);
+  assert.equal(hasValidDocumentId({ docID: 'id not found' }), false);
+  assert.equal(hasValidDocumentId({ docID: '' }), false);
 });


### PR DESCRIPTION
## What changed

- reject Clio link candidates that do not contain a numeric document ID before Faster Suite binds document behavior
- leave custom-field section navigation under Clio's native click handling
- remove a stray candidate debug log
- add regression coverage for invalid document IDs

## Root cause

The extension used broad selectors to find document links but kept candidates even when document ID extraction failed. Custom-field navigation links could therefore be enhanced as documents and trigger a Faster Suite request for `/documents/id not found`, resulting in a Document Access Denied notification instead of scrolling to the selected custom-field section.

## User impact

Custom-field table links now navigate to the intended sections while valid document links keep their Faster Suite enhancements.

## Verification

- red/green regression check
- `npm run check` (10 tests, ESLint, TypeScript, production Vite build)
