### PR TITLE
Prepare extension store release 26.8.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "faster-suit-ext",
-  "version": "26.7.22.1",
+  "version": "26.8.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "faster-suit-ext",
-      "version": "26.7.22.1",
+      "version": "26.8.3.1",
       "license": "MIT",
       "dependencies": {
         "@hookform/resolvers": "^3.10.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "faster-suit-ext",
   "private": true,
-  "version": "26.7.22.1",
+  "version": "26.8.3.1",
   "type": "module",
   "license": "MIT",
   "scripts": {

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -25,4 +25,4 @@ export const SINGLE_DOCUMENT_PAGE_REGEX =
 export const DOCUMENT_URL_REGEX =
   /https?:\/\/ecf\.([a-z]{2,3})\.uscourts\.gov\/doc1\/index\.pl\?.*caseid=[^&]+/;
 
-export const VERSION = '2026.07.22.001';
+export const VERSION = '2026.08.03.001';


### PR DESCRIPTION
## What changed

- bump the Chrome extension package version to `26.8.3.1`
- update the displayed extension version to `2026.08.03.001`
- package the merged custom-field navigation fix for Chrome Web Store upload

## Verification

- `npm run deploy`
- 10 tests passing
- ESLint passing
- TypeScript and production Vite build passing
- packaged manifest reports version `26.8.3.1`
